### PR TITLE
Replace chef call with code test

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -85,7 +85,7 @@ module Chefwaiter
     return '' unless executable_available? && service_installed?
     cmdstr = "\"#{binary_location}\" -v"
 
-    if ::Chef.const_defined?(:Mixin) && ::Chef::Mixin::ShellOut.method_defined?('shell_out_command')
+    if ::Chef.const_defined?(:Mixin) && ::Chef::Mixin.const_defined?(:ShellOut) && ::Chef::Mixin::ShellOut.method_defined?('shell_out_command')
       cmd = ::Chef::Mixin::ShellOut.shell_out_command(cmdstr)
     else
       cmd = ::Mixlib::ShellOut.new(cmdstr).run_command


### PR DESCRIPTION
chef_version is not used anywhere else and it's not really needed for check to work. It will hard fail though if chef is not in chef packages